### PR TITLE
Remove console log

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,6 @@ Player.prototype._addEventedProperty = function (iface, name) {
 			changed[name] = newValue;
 			that.obj.propertyInterface.emitSignal('PropertiesChanged', iface, changed, []);
 
-			console.log('changed', changed);
 		},
 		enumerable: true,
 		configurable: true


### PR DESCRIPTION
Maybe in the future a debug flag could be set in the constructor, but for now removing the console log statement.