### PR TITLE
assert player interface name is valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "0.2.1",
+    "dbus-next": "0.3.1",
     "source-map-support": "^0.5.9"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,8 @@ util.inherits(Player, events.EventEmitter);
 
 Player.prototype.init = function(opts) {
   this.serviceName = `org.mpris.MediaPlayer2.${this.name}`;
+  dbus.validators.assertInterfaceNameValid(this.serviceName);
+
   this._bus = dbus.sessionBus();
 
   this.interfaces = {};


### PR DESCRIPTION
Fail immediately if the interface name of the player determined from
the `name` option of the constructor is not valid.