### PR TITLE
Check properties changed for deep equality

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
     "dbus-next": "^0.3.2",
+    "deep-equal": "^1.0.1",
     "source-map-support": "^0.5.9"
   },
   "devDependencies": {

--- a/src/interfaces/mpris-interface.js
+++ b/src/interfaces/mpris-interface.js
@@ -1,6 +1,7 @@
 let dbus = require('dbus-next');
 let Variant = dbus.Variant;
 let types = require('./types');
+let deepEqual = require('deep-equal');
 
 let {
   Interface, property, method, signal, MethodError,
@@ -35,7 +36,7 @@ class MprisInterface extends Interface {
         valuePlain.filter((t) => t['mpris:trackid']).map((t) => t['mpris:trackid']);
     }
 
-    if (this[`_${property}`] !== valueDbus) {
+    if (!deepEqual(this[`_${property}`], valueDbus)) {
       this[`_${property}`] = valueDbus;
       let changedProperties = {};
       changedProperties[property] = valueDbus;

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -92,9 +92,16 @@ test('getting and setting properties on the player and on the interface should w
       'xesam:title': new Variant('s', 'Rise')
     })
   }
+  expect(cb).toHaveBeenCalledTimes(1);
   expect(cb).toHaveBeenLastCalledWith(PLAYER_IFACE, changed, []);
   let gotten = await props.Get(PLAYER_IFACE, 'Metadata');
   expect(gotten).toEqual(changed.Metadata);
+
+  // setting the metadata again to the same thing should only emit
+  // PropertiesChanged once
+  player.metadata = JSON.parse(JSON.stringify(player.metadata));
+  await ping();
+  expect(cb).toHaveBeenCalledTimes(1);
 
   // PlaybackStatus
   player.playbackStatus = 'Paused';


### PR DESCRIPTION
This allows a player to set metadata to the same thing many times
without emitting a new PropertiesChanged event.