### PR TITLE
Change bus name validation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "0.3.1",
+    "dbus-next": "^0.3.2",
     "source-map-support": "^0.5.9"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ util.inherits(Player, events.EventEmitter);
 
 Player.prototype.init = function(opts) {
   this.serviceName = `org.mpris.MediaPlayer2.${this.name}`;
-  dbus.validators.assertInterfaceNameValid(this.serviceName);
+  dbus.validators.assertBusNameValid(this.serviceName);
 
   this._bus = dbus.sessionBus();
 


### PR DESCRIPTION
Use assertBusNameValid() function to validate bus names instead of the
interface validator to allow dashes in bus names.

Update to dbus-next 0.3.2 and track patch changes.