### PR TITLE
Make MaximumRate and MinimumRate readonly

### DIFF
--- a/src/interfaces/player.js
+++ b/src/interfaces/player.js
@@ -63,20 +63,14 @@ class PlayerInterface extends MprisInterface {
     return this._Metadata;
   }
 
-  @property({signature: 'd'})
+  @property({signature: 'd', access: ACCESS_READ})
   get MaximumRate() {
     return this._MaximumRate;
   }
-  set MaximumRate(value) {
-    this._setPropertyInternal('MaximumRate', value);
-  }
 
-  @property({signature: 'd'})
+  @property({signature: 'd', access: ACCESS_READ})
   get MinimumRate() {
     return this._MinimumRate;
-  }
-  set MinimumRate(value) {
-    this._setPropertyInternal('MinimumRate', value);
   }
 
   @property({signature: 'd'})

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -145,15 +145,19 @@ test('getting and setting properties on the player and on the interface should w
     expect(cb).toHaveBeenLastCalledWith(PLAYER_IFACE, changed, []);
     gotten = await props.Get(PLAYER_IFACE, name);
     expect(gotten).toEqual(new Variant('d', player[playerName]));
-    let playerCb = jest.fn(val => {
-      player[playerName] = val;
-    });
-    player.once(playerName, playerCb);
-    await props.Set(PLAYER_IFACE, name, new Variant('d', 0.15));
-    expect(playerCb).toHaveBeenCalledWith(0.15);
-    expect(player[playerName]).toEqual(0.15);
-    changed[name] = new Variant('d', 0.15);
-    expect(cb).toHaveBeenLastCalledWith(PLAYER_IFACE, changed, []);
+
+    if (name in ['Rate', 'Volume']) {
+      // these are settable by the client
+      let playerCb = jest.fn(val => {
+        player[playerName] = val;
+      });
+      player.once(playerName, playerCb);
+      await props.Set(PLAYER_IFACE, name, new Variant('d', 0.15));
+      expect(playerCb).toHaveBeenCalledWith(0.15);
+      expect(player[playerName]).toEqual(0.15);
+      changed[name] = new Variant('d', 0.15);
+      expect(cb).toHaveBeenLastCalledWith(PLAYER_IFACE, changed, []);
+    }
   }
 
   // The Boolean properties


### PR DESCRIPTION
These are specified to be readonly in mpris and were accidently
implemented as readwrite.