### PR TITLE
PlaybackStatus and LoopStatus enums and validators

### DIFF
--- a/examples/player.js
+++ b/examples/player.js
@@ -36,7 +36,7 @@ setTimeout(function () {
 		'xesam:artist': ['Adele']
 	};
 
-	player.playbackStatus = 'Playing';
+	player.playbackStatus = Player.PLAYBACK_STATUS_PLAYING;
 
 	console.log('Now playing: Lolol - Adele - 21');
 }, 1000);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,31 @@
+const constants = {
+  PLAYBACK_STATUS_PLAYING: 'Playing',
+  PLAYBACK_STATUS_PAUSED: 'Paused',
+  PLAYBACK_STATUS_STOPPED: 'Stopped',
+
+  LOOP_STATUS_NONE: 'None',
+  LOOP_STATUS_TRACK: 'Track',
+  LOOP_STATUS_PLAYLIST: 'Playlist'
+};
+
+const playbackStatuses = [
+  constants.PLAYBACK_STATUS_PLAYING,
+  constants.PLAYBACK_STATUS_PAUSED,
+  constants.PLAYBACK_STATUS_STOPPED
+];
+
+const loopStatuses = [
+  constants.LOOP_STATUS_NONE,
+  constants.LOOP_STATUS_PLAYLIST,
+  constants.LOOP_STATUS_TRACK
+];
+
+constants.isLoopStatusValid = function(value) {
+  return loopStatuses.includes(value);
+};
+
+constants.isPlaybackStatusValid = function(value) {
+  return playbackStatuses.includes(value);
+};
+
+module.exports = constants;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const RootInterface = require('./interfaces/root');
 const PlaylistsInterface = require('./interfaces/playlists');
 const TracklistInterface = require('./interfaces/tracklist');
 const types = require('./interfaces/types');
+const constants = require('./constants');
 
 const MPRIS_PATH = '/org/mpris/MediaPlayer2';
 
@@ -309,5 +310,66 @@ Player.prototype.setPlaylists = function(playlists) {
 Player.prototype.setActivePlaylist = function(playlistId) {
   this.interfaces.playlists.setActivePlaylistId(playlistId);
 };
+
+/**
+ * Enumerated value for the `playbackStatus` property of the player to indicate
+ * a track is currently playing.
+ *
+ * @name Player#PLAYBACK_STATUS_PLAYING
+ * @static
+ * @constant
+ */
+Player.PLAYBACK_STATUS_PLAYING = constants.PLAYBACK_STATUS_PLAYING;
+
+/**
+ * Enumerated value for the `playbackStatus` property of the player to indicate
+ * a track is currently paused.
+ *
+ * @name Player#PLAYBACK_STATUS_PAUSED
+ * @static
+ * @constant
+ */
+Player.PLAYBACK_STATUS_PAUSED = constants.PLAYBACK_STATUS_PAUSED;
+
+/**
+ * Enumerated value for the `playbackStatus` property of the player to indicate
+ * there is no track currently playing.
+ *
+ * @name Player#PLAYBACK_STATUS_STOPPED
+ * @static
+ * @constant
+ */
+Player.PLAYBACK_STATUS_STOPPED = constants.PLAYBACK_STATUS_STOPPED;
+
+/**
+ * Enumerated value for the `loopStatus` property of the player to indicate
+ * playback will stop when there are no more tracks to play.
+ *
+ * @name Player#LOOP_STATUS_NONE
+ * @static
+ * @constant
+ */
+Player.LOOP_STATUS_NONE = constants.LOOP_STATUS_NONE;
+
+/**
+ * Enumerated value for the `loopStatus` property of the player to indicate the
+ * current track will start again from the beginning once it has finished
+ * playing.
+ *
+ * @name Player#LOOP_STATUS_TRACK
+ * @static
+ * @constant
+ */
+Player.LOOP_STATUS_TRACK = constants.LOOP_STATUS_TRACK;
+
+/**
+ * Enumerated value for the `loopStatus` property of the player to indicate the
+ * playback loops through a list of tracks.
+ *
+ * @name Player#LOOP_STATUS_PLAYLIST
+ * @static
+ * @constant
+ */
+Player.LOOP_STATUS_PLAYLIST = constants.LOOP_STATUS_PLAYLIST;
 
 module.exports = Player;

--- a/src/interfaces/player.js
+++ b/src/interfaces/player.js
@@ -2,9 +2,10 @@ const dbus = require('dbus-next');
 const MprisInterface = require('./mpris-interface');
 const Variant = dbus.Variant;
 const JSBI = require('jsbi');
+const constants = require('../constants');
 
 let {
-  property, method, signal, MethodError,
+  property, method, signal, DBusError,
   ACCESS_READ, ACCESS_WRITE, ACCESS_READWRITE
 } = dbus.interface;
 
@@ -25,8 +26,8 @@ class PlayerInterface extends MprisInterface {
   _Rate = 1;
   _Shuffle = false;
   _Volume = 0;
-  _LoopStatus = 'None';
-  _PlaybackStatus = 'Stopped';
+  _LoopStatus = constants.LOOP_STATUS_NONE;
+  _PlaybackStatus = constants.PLAYBACK_STATUS_STOPPED;
 
   @property({signature: 'b', access: ACCESS_READ})
   get CanControl() {
@@ -110,14 +111,31 @@ class PlayerInterface extends MprisInterface {
 
   @property({signature: 's'})
   get LoopStatus() {
+    if (!constants.isLoopStatusValid(this._LoopStatus)) {
+      const err = 'github.mpris_service.InvalidLoopStatusError';
+      const message = `The player has set an invalid loop status: ${this._LoopStatus}`;
+      throw new DBusError(err, message);
+    }
+
     return this._LoopStatus;
   }
   set LoopStatus(value) {
+    if (!constants.isLoopStatusValid(value)) {
+      const err = 'github.mpris_service.InvalidLoopStatusError';
+      const message = `Tried to set loop status to an invalid value: ${value}`;
+      throw new DBusError(err, message);
+    }
     this._setPropertyInternal('LoopStatus', value);
   }
 
   @property({signature: 's', access: ACCESS_READ})
   get PlaybackStatus() {
+    if (!constants.isPlaybackStatusValid(this._PlaybackStatus)) {
+      const err = 'github.mpris_service.InvalidPlaybackStatusError';
+      const message = `The player has set an invalid playback status: ${this._PlaybackStatus}`;
+      throw new DBusError(err, message);
+    }
+
     return this._PlaybackStatus;
   }
 

--- a/src/interfaces/playlists.js
+++ b/src/interfaces/playlists.js
@@ -5,7 +5,7 @@ let Variant = dbus.Variant;
 let types = require('./types');
 
 let {
-  property, method, signal, MethodError,
+  property, method, signal, DBusError,
   ACCESS_READ, ACCESS_WRITE, ACCESS_READWRITE
 } = dbus.interface;
 

--- a/src/interfaces/root.js
+++ b/src/interfaces/root.js
@@ -3,7 +3,7 @@ let dbus = require('dbus-next');
 let Variant = dbus.Variant;
 
 let {
-  property, method, signal, MethodError,
+  property, method, signal, DBusError,
   ACCESS_READ, ACCESS_WRITE, ACCESS_READWRITE
 } = dbus.interface;
 

--- a/src/interfaces/tracklist.js
+++ b/src/interfaces/tracklist.js
@@ -4,7 +4,7 @@ let Variant = dbus.Variant;
 let types = require('./types');
 
 let {
-  property, method, signal, MethodError,
+  property, method, signal, DBusError,
   ACCESS_READ, ACCESS_WRITE, ACCESS_READWRITE
 } = dbus.interface;
 

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,0 +1,13 @@
+let loggingEnabled = (process.env.MPRIS_SERVICE_DEBUG !== undefined && process.env.MPRIS_SERVICE_DEBUG !== '0');
+
+module.exports.debug = function(message) {
+  if (loggingEnabled) {
+    console.log(message);
+  }
+};
+
+module.exports.warn = function(message) {
+  if (loggingEnabled) {
+    console.warn(message);
+  }
+};


### PR DESCRIPTION
Add constants on the Player class for PlaybackStatus and LoopStatus.

When setting the LoopStatus through dbus, validate that the input from
the user is a valid value.

Do not emit PropertiesChanged event when the player has an invalid value
set.

Start on basic logging functions.