### PR TITLE
use tilde for dbus-next dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "^0.3.2",
+    "dbus-next": "~0.3.2",
     "deep-equal": "^1.0.1",
     "source-map-support": "^0.5.9"
   },


### PR DESCRIPTION
This library may make breaking changes in minor versions, so don't
automatically update to major versions until 1.0.