### PR TITLE
Player error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "^0.3.2",
+    "dbus-next": "^0.4.1",
     "deep-equal": "^1.0.1",
     "source-map-support": "^0.5.9"
   },

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,4 @@
+module.exports.ping = async function(bus) {
+  let busObj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
+  return busObj.getInterface('org.freedesktop.DBus').ListNames();
+}

--- a/test/root.test.js
+++ b/test/root.test.js
@@ -1,6 +1,8 @@
+jest.setTimeout(1e4);
 let dbus = require('dbus-next');
 let Variant = dbus.Variant;
 let Player = require('../dist');
+let { ping } = require('./fixtures');
 
 const ROOT_IFACE = 'org.mpris.MediaPlayer2';
 const PLAYER_IFACE = 'org.mpris.MediaPlayer2.Player';
@@ -17,7 +19,15 @@ var player = Player({
   supportedInterfaces: ['player']
 });
 
+player.on('error', (err) => {
+  console.log(`got unexpected error:\n${err.stack}`);
+});
+
 let bus = dbus.sessionBus();
+
+beforeAll(async () => {
+  return await ping(bus);
+});
 
 afterAll(() => {
   player._bus.connection.stream.end();
@@ -37,17 +47,13 @@ test('calling methods should raise a signal on the player', async () => {
   player.once('raise', cb);
   await root.Raise();
   expect(cb).toHaveBeenCalledWith();
+  await ping(bus);
 });
 
 test('setting properties on the player should show up on dbus and raise a signal', async () => {
   let obj = await bus.getProxyObject('org.mpris.MediaPlayer2.roottest', '/org/mpris/MediaPlayer2');
   let root = obj.getInterface(ROOT_IFACE);
   let props = obj.getInterface('org.freedesktop.DBus.Properties');
-  let dbusObj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
-
-  let ping = async () => {
-    return dbusObj.getInterface('org.freedesktop.DBus').ListNames();
-  };
 
   let cb = jest.fn();
   props.on('PropertiesChanged', cb);
@@ -60,7 +66,7 @@ test('setting properties on the player should show up on dbus and raise a signal
     expect(gotten).toEqual(new Variant('as', player[playerName]));
     let newValue = ['foo', 'bar'];
     player[playerName] = newValue;
-    await ping();
+    await ping(bus);
     let changed = {};
     changed[name] = new Variant('as', newValue);
     expect(cb).toHaveBeenLastCalledWith(ROOT_IFACE, changed, []);
@@ -72,7 +78,7 @@ test('setting properties on the player should show up on dbus and raise a signal
     let playerName = lcFirst(name);
     let newValue = !player[playerName];
     player[playerName] = newValue;
-    await ping();
+    await ping(bus);
     changed = {};
     changed[name] = new Variant('b', newValue);
     expect(cb).toHaveBeenCalledWith(ROOT_IFACE, changed, []);
@@ -86,7 +92,7 @@ test('setting properties on the player should show up on dbus and raise a signal
     let playerName = lcFirst(name);
     let newValue = 'foo';
     player[playerName] = newValue;
-    await ping();
+    await ping(bus);
     changed = {};
     changed[name] = new Variant('s', newValue);
     expect(cb).toHaveBeenCalledWith(ROOT_IFACE, changed, []);
@@ -99,9 +105,10 @@ test('setting properties on the player should show up on dbus and raise a signal
   expect(gotten).toEqual(new Variant('b', player.fullscreen));
   let newValue = !player.fullscreen;
   player.fullscreen = newValue;
-  await ping();
+  await ping(bus);
   changed = {
     Fullscreen: new Variant('b', newValue)
   };
   expect(cb).toHaveBeenLastCalledWith(ROOT_IFACE, changed, []);
+  await ping(bus);
 });


### PR DESCRIPTION
Add an `error` event to the Player so users can handle DBus connection
errors. Proxy dbus connection and export errors through this event.

Update dbus-next to 0.4 and use the new interface export api.

Update tests for the new features and add a `ping` fixture.

fixes #32