### PR TITLE
Support multiple instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "^0.4.1",
+    "dbus-next": "^0.4.2",
     "deep-equal": "^1.0.1",
     "source-map-support": "^0.5.9"
   },

--- a/test/multiple-instances.test.js
+++ b/test/multiple-instances.test.js
@@ -1,0 +1,53 @@
+jest.setTimeout(1e4);
+const dbus = require('dbus-next');
+const Player = require('../dist');
+
+let initErrors = [];
+let playerName = 'multiple_instances';
+
+function errorHandler(err) {
+  console.log(err.stack);
+  initErrors.push(err);
+}
+
+let player1 = Player({
+  name: playerName,
+  identity: 'Node.js media player',
+  supportedUriSchemes: ['file'],
+  supportedMimeTypes: ['audio/mpeg', 'application/ogg'],
+  supportedInterfaces: ['player']
+});
+
+player1.on('error', errorHandler);
+
+let player2 = Player({
+  name: playerName,
+  identity: 'Node.js media player',
+  supportedUriSchemes: ['file'],
+  supportedMimeTypes: ['audio/mpeg', 'application/ogg'],
+  supportedInterfaces: ['player']
+});
+
+player2.on('error', errorHandler);
+
+let bus = dbus.sessionBus();
+
+afterAll(() => {
+  player1._bus.connection.stream.end();
+  player2._bus.connection.stream.end();
+  bus.connection.stream.end();
+});
+
+test('creating two players with the same name on the same bus should create the second one as an instance', async () => {
+  let dbusObj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
+  let dbusIface = dbusObj.getInterface('org.freedesktop.DBus');
+  let names = await dbusIface.ListNames();
+
+  expect(initErrors).toHaveLength(0);
+
+  let expectedIfaces = [
+    `org.mpris.MediaPlayer2.${playerName}`,
+    `org.mpris.MediaPlayer2.${playerName}.instance${process.pid}`,
+  ];
+  expect(names).toEqual(expect.arrayContaining(expectedIfaces));
+});


### PR DESCRIPTION
https://specifications.freedesktop.org/mpris-spec/latest/#Bus-Name-Policy

In the case where the media player allows multiple instances running
simultaneously, each additional instance should request a unique bus
name, adding a dot and a unique identifier to its usual bus name, such
as one based on a UNIX process id.

fixes #31