### PR TITLE
Update to dbus-next 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "^0.4.2",
+    "dbus-next": "^0.5.1",
     "deep-equal": "^1.0.1",
     "source-map-support": "^0.5.9"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ Player.prototype.init = function(opts) {
 
   this._bus = dbus.sessionBus();
 
-  this._bus.connection.on('error', (err) => {
+  this._bus.on('error', (err) => {
     this.emit('error', err);
   });
 

--- a/test/multiple-instances.test.js
+++ b/test/multiple-instances.test.js
@@ -33,9 +33,9 @@ player2.on('error', errorHandler);
 let bus = dbus.sessionBus();
 
 afterAll(() => {
-  player1._bus.connection.stream.end();
-  player2._bus.connection.stream.end();
-  bus.connection.stream.end();
+  player1._bus.disconnect();
+  player2._bus.disconnect();
+  bus.disconnect();
 });
 
 test('creating two players with the same name on the same bus should create the second one as an instance', async () => {

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -28,8 +28,8 @@ player.on('error', (err) => {
 let bus = dbus.sessionBus();
 
 afterAll(() => {
-  player._bus.connection.stream.end();
-  bus.connection.stream.end();
+  player._bus.disconnect();
+  bus.disconnect();
 });
 
 test('creating a player exports the root and player interfaces on the bus', async () => {

--- a/test/playlists.test.js
+++ b/test/playlists.test.js
@@ -27,8 +27,8 @@ player.on('error', (err) => {
 let bus = dbus.sessionBus();
 
 afterAll(() => {
-  player._bus.connection.stream.end();
-  bus.connection.stream.end();
+  player._bus.disconnect();
+  bus.disconnect();
 });
 
 test('creating a player exports the playlists interfaces on the bus', async () => {

--- a/test/root.test.js
+++ b/test/root.test.js
@@ -25,13 +25,13 @@ player.on('error', (err) => {
 let bus = dbus.sessionBus();
 
 afterAll(() => {
-  player._bus.connection.stream.end();
-  bus.connection.stream.end();
+  player._bus.disconnect();
+  bus.disconnect();
 });
 
 test('calling methods should raise a signal on the player', async () => {
   let obj = await bus.getProxyObject('org.mpris.MediaPlayer2.roottest', '/org/mpris/MediaPlayer2');
-  let root = obj.getInterface(ROOT_IFACE);
+  let root = obj.interfaces[ROOT_IFACE];
 
   if (!root) {
     // XXX need to wait a beat for the service to start up


### PR DESCRIPTION
The `connection` member of the bus has been made private. Errors are
forwarded to the bus itself. Use the new `disconnect()` method to
diconnect from the bus during testing.